### PR TITLE
MSL: Fix uninitialized attributeCallback

### DIFF
--- a/src/MSLGenerator.h
+++ b/src/MSLGenerator.h
@@ -39,6 +39,7 @@ public:
         {
             flags = 0;
             bufferRegisterOffset = 0;
+            attributeCallback = NULL;
         }
     };
 


### PR DESCRIPTION
Not super important since it's unlikely not-setting this has a valid use but still worthwhile.