### PR TITLE
HLSL: Fix return; parsing

### DIFF
--- a/src/HLSLParser.cpp
+++ b/src/HLSLParser.cpp
@@ -1670,7 +1670,8 @@ bool HLSLParser::ParseStatement(HLSLStatement*& statement, const HLSLType& retur
             return false;
         }
         // Check that the return expression can be cast to the return type of the function.
-        if (!CheckTypeCast(returnStatement->expression->expressionType, returnType))
+        HLSLType voidType(HLSLBaseType_Void);
+        if (!CheckTypeCast(returnStatement->expression ? returnStatement->expression->expressionType : voidType, returnType))
         {
             return false;
         }


### PR DESCRIPTION
It seems like other paths through the code handle this fine, miraculously.