### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -125,8 +125,12 @@ static char *mprintf_valist(int size, const char *fmt, va_list args) {
     va_list tmp;
 
     while (1) {
-        res = new char[size];
-        if (!res) return NULL;
+		try {
+			res = new char[size];
+		}
+		catch (std::bad_alloc& ba) {
+			return NULL;
+		}
 
         va_copy(tmp, args);
         int len = vsnprintf(res, size, fmt, tmp);


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V668](https://www.viva64.com/en/w/v668/) There is no sense in testing the 'res' pointer against null, as the memory was allocated using the 'new' 
operator. The exception will be generated in the case of memory allocation error. engine.cpp 129