### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/src/HLSLTokenizer.cpp
+++ b/src/HLSLTokenizer.cpp
@@ -623,6 +623,7 @@ void HLSLTokenizer::GetTokenName(int token, char buffer[s_maxIdentifier])
             break;
         case HLSLToken_EndOfStream:
             strcpy(buffer, "<eof>");
+			break;
         default:
             strcpy(buffer, "unknown");
             break;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V796](https://www.viva64.com/en/w/v796/) It is possible that 'break' statement is missing in switch statement. hlsltokenizer.cpp 625