### PR TITLE
MSL: Add support for texture arrays

### DIFF
--- a/src/MSLGenerator.cpp
+++ b/src/MSLGenerator.cpp
@@ -1480,7 +1480,7 @@ void MSLGenerator::OutputDeclarationType(const HLSLType& type, bool isRef, bool 
             typeName = "TextureCubeSampler";
         else if (type.baseType == HLSLBaseType_Sampler2DShadow)
             typeName = "Texture2DShadowSampler";
-        else if (type.baseType == HLSLBaseType_Sampler2DShadow)
+        else if (type.baseType == HLSLBaseType_Sampler2DMS)
             typeName = "Texture2DMSSampler";
         else
             typeName = "<unhandled texture type>";

--- a/src/MSLGenerator.cpp
+++ b/src/MSLGenerator.cpp
@@ -629,14 +629,14 @@ void MSLGenerator::PrependDeclarations()
         m_writer.WriteLine(0, "}");
     }
 
-    m_writer.WriteLine(0, "struct Texture2DArraySampler {");
-    m_writer.WriteLine(1, "const thread texture2d_array<float>& t;");
-    m_writer.WriteLine(1, "const thread sampler& s;");
-    m_writer.WriteLine(1, "Texture2DArraySampler(thread const texture2d_array<float>& t, thread const sampler& s) : t(t), s(s) {};");
-    m_writer.WriteLine(0, "};");
-
     if (m_tree->NeedsFunction("tex2DArray"))
     {
+        m_writer.WriteLine(0, "struct Texture2DArraySampler {");
+        m_writer.WriteLine(1, "const thread texture2d_array<float>& t;");
+        m_writer.WriteLine(1, "const thread sampler& s;");
+        m_writer.WriteLine(1, "Texture2DArraySampler(thread const texture2d_array<float>& t, thread const sampler& s) : t(t), s(s) {};");
+        m_writer.WriteLine(0, "};");
+
         m_writer.WriteLine(0, "inline float4 tex2DArray(Texture2DArraySampler ts, float3 texCoord) {");
         m_writer.WriteLine(1, "return ts.t.sample(ts.s, texCoord.xy, texCoord.z + 0.5);"); // 0.5 offset needed on nvidia gpus
         m_writer.WriteLine(0, "}");

--- a/src/MSLGenerator.cpp
+++ b/src/MSLGenerator.cpp
@@ -75,6 +75,7 @@ static const char* GetTypeName(const HLSLType& type)
     case HLSLBaseType_SamplerCube:      return "texturecube<float>";
     case HLSLBaseType_Sampler2DShadow:  return "depth2d<float>";
     case HLSLBaseType_Sampler2DMS:      return "texture2d_ms<float>";
+    case HLSLBaseType_Sampler2DArray:   return "texture2d_array<float>";
     case HLSLBaseType_UserDefined:      return type.typeName;
     default:
         ASSERT(0);
@@ -627,6 +628,19 @@ void MSLGenerator::PrependDeclarations()
         m_writer.WriteLine(1, "return t.read(uint2(texCoord), sample);");
         m_writer.WriteLine(0, "}");
     }
+
+    m_writer.WriteLine(0, "struct Texture2DArraySampler {");
+    m_writer.WriteLine(1, "const thread texture2d_array<float>& t;");
+    m_writer.WriteLine(1, "const thread sampler& s;");
+    m_writer.WriteLine(1, "Texture2DArraySampler(thread const texture2d_array<float>& t, thread const sampler& s) : t(t), s(s) {};");
+    m_writer.WriteLine(0, "};");
+
+    if (m_tree->NeedsFunction("tex2DArray"))
+    {
+        m_writer.WriteLine(0, "inline float4 tex2DArray(Texture2DArraySampler ts, float3 texCoord) {");
+        m_writer.WriteLine(1, "return ts.t.sample(ts.s, texCoord.xy, texCoord.z + 0.5);"); // 0.5 offset needed on nvidia gpus
+        m_writer.WriteLine(0, "}");
+    }
 }
     
 bool MSLGenerator::Generate(HLSLTree* tree, Target target, const char* entryName, const Options& options)
@@ -1050,6 +1064,8 @@ void MSLGenerator::OutputDeclaration(HLSLDeclaration* declaration)
             m_writer.Write("thread depth2d<float>& %s_texture; thread sampler& %s_sampler", declaration->name, declaration->name);
         else if (declaration->type.baseType == HLSLBaseType_Sampler2DMS)
             m_writer.Write("thread texture2d_ms<float>& %s_texture", declaration->name);
+        else if (declaration->type.baseType == HLSLBaseType_Sampler2DArray)
+            m_writer.Write("thread texture2d_array<float>& %s_texture; thread sampler& %s_sampler", declaration->name, declaration->name);
         else
             m_writer.Write("<unhandled texture type>");
     }
@@ -1170,6 +1186,8 @@ void MSLGenerator::OutputExpression(HLSLExpression* expression, HLSLExpression* 
                 m_writer.Write("Texture2DShadowSampler(%s_texture, %s_sampler)", name, name);
             else if (identifierExpression->expressionType.baseType == HLSLBaseType_Sampler2DMS)
                 m_writer.Write("%s_texture", name);
+            else if (identifierExpression->expressionType.baseType == HLSLBaseType_Sampler2DArray)
+                m_writer.Write("Texture2DArraySampler(%s_texture, %s_sampler)", name, name);
             else
                 m_writer.Write("<unhandled texture type>");
         }
@@ -1482,6 +1500,8 @@ void MSLGenerator::OutputDeclarationType(const HLSLType& type, bool isRef, bool 
             typeName = "Texture2DShadowSampler";
         else if (type.baseType == HLSLBaseType_Sampler2DMS)
             typeName = "Texture2DMSSampler";
+        else if (type.baseType == HLSLBaseType_Sampler2DArray)
+            typeName = "Texture2DArraySampler";
         else
             typeName = "<unhandled texture type>";
     }


### PR DESCRIPTION
We add 0.5 to layer index to match round-to-nearest semantics expected by HLSL code.

Without doing that, on NVidia GPUs rasterizer can have a slight rounding error if you pass the texture array layer via interpolator, and the implicit cast inside `sample` call would truncate something like 3.999999 to 3.