### PR TITLE
MSL: Change tex2DMSfetch signature to use int2 inputs

### DIFF
--- a/src/MSLGenerator.cpp
+++ b/src/MSLGenerator.cpp
@@ -620,11 +620,7 @@ void MSLGenerator::PrependDeclarations()
     
     if (m_tree->NeedsFunction("tex2DMSfetch"))
     {
-        m_writer.WriteLine(0, "inline float4 tex2DMSfetch(texture2d_ms<float> t, uint2 texCoord, uint sample) {");
-        m_writer.WriteLine(1, "return t.read(texCoord, sample);");
-        m_writer.WriteLine(0, "}");
-
-        m_writer.WriteLine(0, "inline float4 tex2DMSfetch(texture2d_ms<float> t, float2 texCoord, uint sample) {");
+        m_writer.WriteLine(0, "inline float4 tex2DMSfetch(texture2d_ms<float> t, int2 texCoord, int sample) {");
         m_writer.WriteLine(1, "return t.read(uint2(texCoord), sample);");
         m_writer.WriteLine(0, "}");
     }


### PR DESCRIPTION
This fixes a compilation issue with passing `int2` to tex2Dmsfetch - Metal compiler can't pick the right overload.

It's possible to fix this by also adding an int2 overload but I felt that just using int2 makes more sense - this matches GLSL and DX11 semantics for fetching (e.g. https://msdn.microsoft.com/en-us/library/windows/desktop/bb509694(v=vs.85).aspx).