### PR TITLE
MSL: Remove 2-arity tex2Dmsfetch

### DIFF
--- a/src/MSLGenerator.cpp
+++ b/src/MSLGenerator.cpp
@@ -534,13 +534,6 @@ void MSLGenerator::PrependDeclarations()
         m_writer.WriteLine(0, "}");
     }
     
-    if (m_tree->NeedsFunction("tex2DMSfetch"))
-    {
-        m_writer.WriteLine(0, "inline float4 tex2DMSfetch(texture2d_ms<float> t, float2 texCoord) {");
-        m_writer.WriteLine(1, "return ts.t.read(uint2(texCoord));");
-        m_writer.WriteLine(0, "}");
-    }
-
     if (m_tree->NeedsFunction("tex3D") ||
         m_tree->NeedsFunction("tex3Dlod"))
     {


### PR DESCRIPTION
When merging our fork with this one one of the shaders that uses tex2Dmsfetch didn't compile for MSL for us because one of the overloads was invalid. I think it's a regression from 4221154909ef837b08c882a714dfb64e379b7695.

This change just removes it; this assumes that The Witness does *not* actually use this overload :) If you guys do I could rework this change somehow.