### PR TITLE
MSL: Allow SV_Position as an input to fragment shader

### DIFF
--- a/src/MSLGenerator.cpp
+++ b/src/MSLGenerator.cpp
@@ -1751,6 +1751,7 @@ const char* MSLGenerator::TranslateInputSemantic(const char * semantic)
     else if (m_target == MSLGenerator::Target_FragmentShader)
     {
         if (String_Equal(semantic, "POSITION")) return "position";
+        if (String_Equal(semantic, "SV_Position")) return "position";
         if (String_Equal(semantic, "VFACE")) return "front_facing";
         if (String_Equal(semantic, "TARGET_INDEX")) return "render_target_array_index";
     }


### PR DESCRIPTION
This allows fragment shader to read pixel position in MSL (GLSL already supports this via gl_FragCoord translation).