### PR TITLE
Merge changes from The Witness for iOS.

### DIFF
--- a/src/GLSLGenerator.cpp
+++ b/src/GLSLGenerator.cpp
@@ -447,7 +447,7 @@ void GLSLGenerator::OutputExpressionList(HLSLExpression* expression, HLSLArgumen
 
 const HLSLType* commonScalarType(const HLSLType& lhs, const HLSLType& rhs)
 {
-    if (!isScalarType(lhs) || !isScalarType(rhs))
+    if (!IsScalarType(lhs) || !IsScalarType(rhs))
         return NULL;
 
     if (lhs.baseType == HLSLBaseType_Float || lhs.baseType == HLSLBaseType_Half ||
@@ -571,8 +571,8 @@ void GLSLGenerator::OutputExpression(HLSLExpression* expression, const HLSLType*
         const HLSLType* dstType2 = NULL;
 
 		//
-		bool vectorExpression = isVectorType( binaryExpression->expression1->expressionType ) || isVectorType( binaryExpression->expression2->expressionType );
-		if( vectorExpression && isCompareOp( binaryExpression->binaryOp ))
+		bool vectorExpression = IsVectorType( binaryExpression->expression1->expressionType ) || IsVectorType( binaryExpression->expression2->expressionType );
+		if( vectorExpression && IsCompareOp( binaryExpression->binaryOp ))
 		{
 			switch (binaryExpression->binaryOp)
 			{
@@ -586,9 +586,9 @@ void GLSLGenerator::OutputExpression(HLSLExpression* expression, const HLSLType*
 				ASSERT(0); // is so, check isCompareOp
 			}
 
-			if( isVectorType( binaryExpression->expression1->expressionType ) && isScalarType( binaryExpression->expression2->expressionType ) )
+			if( IsVectorType( binaryExpression->expression1->expressionType ) && IsScalarType( binaryExpression->expression2->expressionType ) )
 				dstType2 = &binaryExpression->expression1->expressionType;
-			else if( isScalarType( binaryExpression->expression1->expressionType ) && isVectorType( binaryExpression->expression2->expressionType ) )
+			else if( IsScalarType( binaryExpression->expression1->expressionType ) && IsVectorType( binaryExpression->expression2->expressionType ) )
 				dstType1 = &binaryExpression->expression2->expressionType;
 			// TODO if both expressions are vector but with different dimension handle it here or in parser?
 
@@ -619,8 +619,8 @@ void GLSLGenerator::OutputExpression(HLSLExpression* expression, const HLSLType*
 			case HLSLBinaryOp_And:          op = " && "; dstType1 = dstType2 = &binaryExpression->expressionType; break;
 			case HLSLBinaryOp_Or:           op = " || "; dstType1 = dstType2 = &binaryExpression->expressionType; break;
 			case HLSLBinaryOp_BitAnd:       op = " & "; dstType1 = dstType2 = commonScalarType(binaryExpression->expression1->expressionType, binaryExpression->expression2->expressionType); break;
-			case HLSLBinaryOp_BitOr:	op = " | "; dstType1 = dstType2 = commonScalarType(binaryExpression->expression1->expressionType, binaryExpression->expression2->expressionType); break;
-			case HLSLBinaryOp_BitXor:	op = " ^ "; dstType1 = dstType2 = commonScalarType(binaryExpression->expression1->expressionType, binaryExpression->expression2->expressionType); break;
+			case HLSLBinaryOp_BitOr:        op = " | "; dstType1 = dstType2 = commonScalarType(binaryExpression->expression1->expressionType, binaryExpression->expression2->expressionType); break;
+			case HLSLBinaryOp_BitXor:       op = " ^ "; dstType1 = dstType2 = commonScalarType(binaryExpression->expression1->expressionType, binaryExpression->expression2->expressionType); break;
 			default:
 				ASSERT(0);
 			}
@@ -634,7 +634,7 @@ void GLSLGenerator::OutputExpression(HLSLExpression* expression, const HLSLType*
     else if (expression->nodeType == HLSLNodeType_ConditionalExpression)
     {
         HLSLConditionalExpression* conditionalExpression = static_cast<HLSLConditionalExpression*>(expression);
-		if( isVectorType( conditionalExpression->condition->expressionType ) )
+		if( IsVectorType( conditionalExpression->condition->expressionType ) )
 		{
 			m_writer.Write( "%s", m_bvecTernary );
 			m_writer.Write( "( " );

--- a/src/HLSLGenerator.cpp
+++ b/src/HLSLGenerator.cpp
@@ -32,15 +32,15 @@ static const char* GetTypeName(const HLSLType& type)
     case HLSLBaseType_Float4x4:     return "float4x4";
     case HLSLBaseType_Float4x3:     return "float4x3";
     case HLSLBaseType_Float4x2:     return "float4x2";
-    case HLSLBaseType_Half:         return "half";
-    case HLSLBaseType_Half2:        return "half2";
-    case HLSLBaseType_Half3:        return "half3";
-    case HLSLBaseType_Half4:        return "half4";
-	case HLSLBaseType_Half2x2:      return "half2x2";
-    case HLSLBaseType_Half3x3:      return "half3x3";
-    case HLSLBaseType_Half4x4:      return "half4x4";
-    case HLSLBaseType_Half4x3:      return "half4x3";
-    case HLSLBaseType_Half4x2:      return "half4x2";
+    case HLSLBaseType_Half:        return "float";
+    case HLSLBaseType_Half2:       return "float2";
+    case HLSLBaseType_Half3:       return "float3";
+    case HLSLBaseType_Half4:       return "float4";
+    case HLSLBaseType_Half2x2:     return "float2x2";
+    case HLSLBaseType_Half3x3:     return "float3x3";
+    case HLSLBaseType_Half4x4:     return "float4x4";
+    case HLSLBaseType_Half4x3:     return "float4x3";
+    case HLSLBaseType_Half4x2:     return "float4x2";
     case HLSLBaseType_Bool:         return "bool";
 	case HLSLBaseType_Bool2:        return "bool2";
 	case HLSLBaseType_Bool3:        return "bool3";
@@ -749,6 +749,8 @@ void HLSLGenerator::OutputArguments(HLSLArgument* argument)
             break;
         case HLSLArgumentModifier_Uniform:
             m_writer.Write("uniform ");
+            break;
+        default:
             break;
         }
 

--- a/src/HLSLParser.cpp
+++ b/src/HLSLParser.cpp
@@ -27,6 +27,7 @@ enum CompareFunctionsResult
     Function2Better
 };
 
+    
 /** This structure stores a HLSLFunction-like declaration for an intrinsic function */
 struct Intrinsic
 {
@@ -93,6 +94,14 @@ struct Intrinsic
     HLSLFunction    function;
     HLSLArgument    argument[4];
 };
+    
+Intrinsic SamplerIntrinsic(const char* name, HLSLBaseType returnType, HLSLBaseType arg1, HLSLBaseType samplerType, HLSLBaseType arg2)
+{
+    Intrinsic i(name, returnType, arg1, arg2);
+    i.argument[0].type.samplerType = samplerType;
+    return i;
+}
+
 
 enum NumericType
 {
@@ -411,15 +420,25 @@ struct BaseTypeDescription
 
 #define INTRINSIC_FLOAT3_FUNCTION(name) \
         Intrinsic( name, HLSLBaseType_Float,   HLSLBaseType_Float,   HLSLBaseType_Float,  HLSLBaseType_Float ),   \
-        Intrinsic( name, HLSLBaseType_Float2,  HLSLBaseType_Float2,  HLSLBaseType_Float,  HLSLBaseType_Float2 ),  \
-        Intrinsic( name, HLSLBaseType_Float3,  HLSLBaseType_Float3,  HLSLBaseType_Float,  HLSLBaseType_Float3 ),  \
-        Intrinsic( name, HLSLBaseType_Float4,  HLSLBaseType_Float4,  HLSLBaseType_Float,  HLSLBaseType_Float4 ),  \
+        Intrinsic( name, HLSLBaseType_Float2,  HLSLBaseType_Float2,  HLSLBaseType_Float2,  HLSLBaseType_Float2 ),  \
+        Intrinsic( name, HLSLBaseType_Float3,  HLSLBaseType_Float3,  HLSLBaseType_Float3,  HLSLBaseType_Float3 ),  \
+        Intrinsic( name, HLSLBaseType_Float4,  HLSLBaseType_Float4,  HLSLBaseType_Float4,  HLSLBaseType_Float4 ),  \
         Intrinsic( name, HLSLBaseType_Half,    HLSLBaseType_Half,    HLSLBaseType_Half,   HLSLBaseType_Half ),    \
-        Intrinsic( name, HLSLBaseType_Half2,   HLSLBaseType_Half2,   HLSLBaseType_Half2,  HLSLBaseType_Half2 ),   \
-        Intrinsic( name, HLSLBaseType_Half3,   HLSLBaseType_Half3,   HLSLBaseType_Half3,  HLSLBaseType_Half3 ),   \
+        Intrinsic( name, HLSLBaseType_Half2,   HLSLBaseType_Half2,   HLSLBaseType_Half2,  HLSLBaseType_Half2 ),    \
+        Intrinsic( name, HLSLBaseType_Half3,   HLSLBaseType_Half3,   HLSLBaseType_Half3,  HLSLBaseType_Half3 ),    \
         Intrinsic( name, HLSLBaseType_Half4,   HLSLBaseType_Half4,   HLSLBaseType_Half4,  HLSLBaseType_Half4 )
 
-const Intrinsic _intrinsic[] = 
+#if 0
+// @@ IC: For some reason this is not working with the Visual Studio compiler:
+#define SAMPLER_INTRINSIC_FUNCTION(name, sampler, arg1) \
+        SamplerIntrinsic( name, HLSLBaseType_Float4, sampler, HLSLBaseType_Float, arg1),   \
+        SamplerIntrinsic( name, HLSLBaseType_Half4,  sampler, HLSLBaseType_Half,  arg1  )
+#else
+#define SAMPLER_INTRINSIC_FUNCTION(name, sampler, arg1) \
+        Intrinsic( name, HLSLBaseType_Float4, sampler, arg1)
+#endif
+    
+const Intrinsic _intrinsic[] =
     {
         INTRINSIC_FLOAT1_FUNCTION( "abs" ),
         INTRINSIC_FLOAT1_FUNCTION( "acos" ),
@@ -521,6 +540,9 @@ const Intrinsic _intrinsic[] =
 		Intrinsic( "transpose", HLSLBaseType_Float2x2, HLSLBaseType_Float2x2 ),
         Intrinsic( "transpose", HLSLBaseType_Float3x3, HLSLBaseType_Float3x3 ),
         Intrinsic( "transpose", HLSLBaseType_Float4x4, HLSLBaseType_Float4x4 ),
+        Intrinsic( "transpose", HLSLBaseType_Half2x2, HLSLBaseType_Half2x2 ),
+        Intrinsic( "transpose", HLSLBaseType_Half3x3, HLSLBaseType_Half3x3 ),
+        Intrinsic( "transpose", HLSLBaseType_Half4x4, HLSLBaseType_Half4x4 ),
 
         INTRINSIC_FLOAT1_FUNCTION( "normalize" ),
         INTRINSIC_FLOAT2_FUNCTION( "pow" ),
@@ -545,11 +567,17 @@ const Intrinsic _intrinsic[] =
 		INTRINSIC_FLOAT1_FUNCTION("isinf"),
 
 		Intrinsic("asuint",    HLSLBaseType_Uint, HLSLBaseType_Float),
-        Intrinsic("tex2D",     HLSLBaseType_Float4, HLSLBaseType_Sampler2D, HLSLBaseType_Float2),
+
+        SAMPLER_INTRINSIC_FUNCTION("tex2D", HLSLBaseType_Sampler2D, HLSLBaseType_Float2),
+        
         Intrinsic("tex2Dproj", HLSLBaseType_Float4, HLSLBaseType_Sampler2D, HLSLBaseType_Float4),
-        Intrinsic("tex2Dlod",  HLSLBaseType_Float4, HLSLBaseType_Sampler2D, HLSLBaseType_Float4),
+
+        SAMPLER_INTRINSIC_FUNCTION("tex2Dlod", HLSLBaseType_Sampler2D, HLSLBaseType_Float4),
+        
         Intrinsic("tex2Dlod",  HLSLBaseType_Float4, HLSLBaseType_Sampler2D, HLSLBaseType_Float4, HLSLBaseType_Int2),   // With offset.
-        Intrinsic("tex2Dbias", HLSLBaseType_Float4, HLSLBaseType_Sampler2D, HLSLBaseType_Float4),
+
+        SAMPLER_INTRINSIC_FUNCTION("tex2Dbias", HLSLBaseType_Sampler2D, HLSLBaseType_Float4),
+        
         Intrinsic("tex2Dgrad", HLSLBaseType_Float4, HLSLBaseType_Sampler2D, HLSLBaseType_Float2, HLSLBaseType_Float2, HLSLBaseType_Float2),
         Intrinsic("tex2Dgather", HLSLBaseType_Float4, HLSLBaseType_Sampler2D, HLSLBaseType_Float2, HLSLBaseType_Int),
         Intrinsic("tex2Dgather", HLSLBaseType_Float4, HLSLBaseType_Sampler2D, HLSLBaseType_Float2, HLSLBaseType_Int2, HLSLBaseType_Int),    // With offset.
@@ -624,7 +652,7 @@ const BaseTypeDescription _baseTypeDescriptions[HLSLBaseType_Count] =
         { "half2",              NumericType_Half,       2, 1, 1,  1 },      // HLSLBaseType_Half2
         { "half3",              NumericType_Half,       3, 1, 1,  1 },      // HLSLBaseType_Half3
         { "half4",              NumericType_Half,       4, 1, 1,  1 },      // HLSLBaseType_Half4
-		{ "half2x2",		NumericType_Float,		 2, 2, 2, 0 },		// HLSLBaseType_Half2x2
+		{ "half2x2",            NumericType_Float,		2, 2, 2,  0 },		// HLSLBaseType_Half2x2
         { "half3x3",            NumericType_Half,       3, 2, 3,  1 },      // HLSLBaseType_Half3x3
         { "half4x4",            NumericType_Half,       4, 2, 4,  1 },      // HLSLBaseType_Half4x4
         { "half4x3",            NumericType_Half,       4, 2, 3,  1 },      // HLSLBaseType_Half4x3
@@ -653,7 +681,8 @@ const BaseTypeDescription _baseTypeDescriptions[HLSLBaseType_Count] =
         { "sampler2DShadow",    NumericType_NaN,        1, 0, 0, -1 },      // HLSLBaseType_Sampler2DShadow
         { "sampler2DMS",        NumericType_NaN,        1, 0, 0, -1 },      // HLSLBaseType_Sampler2DMS
         { "sampler2DArray",     NumericType_NaN,        1, 0, 0, -1 },      // HLSLBaseType_Sampler2DArray
-        { "user defined",       NumericType_NaN,        1, 0, 0, -1 }       // HLSLBaseType_UserDefined
+        { "user defined",       NumericType_NaN,        1, 0, 0, -1 },      // HLSLBaseType_UserDefined
+        { "expression",         NumericType_NaN,        1, 0, 0, -1 }       // HLSLBaseType_Expression
     };
 
 // IC: I'm not sure this table is right, but any errors should be caught by the backend compiler.
@@ -960,6 +989,11 @@ static int GetTypeCastRank(HLSLTree * tree, const HLSLType& srcType, const HLSLT
 
     if (srcType.baseType == dstType.baseType)
     {
+        if (IsSamplerType(srcType.baseType))
+        {
+            return srcType.samplerType == dstType.samplerType ? 0 : -1;
+        }
+        
         return 0;
     }
 
@@ -1254,9 +1288,10 @@ bool HLSLParser::ParseTopLevel(HLSLStatement*& statement)
     int line             = GetLineNumber();
     const char* fileName = GetFileName();
     
-    HLSLBaseType type;
-    const char*  typeName = NULL;
-    int          typeFlags = false;
+    HLSLType type;
+    //HLSLBaseType type;
+    //const char*  typeName = NULL;
+    //int          typeFlags = false;
 
     bool doesNotExpectSemicolon = false;
 
@@ -1367,7 +1402,7 @@ bool HLSLParser::ParseTopLevel(HLSLStatement*& statement)
 
         statement = buffer;
     }
-    else if (AcceptType(true, type, typeName, &typeFlags))
+    else if (AcceptType(true, type))
     {
         // Global declaration (uniform or function).
         const char* globalName = NULL;
@@ -1382,12 +1417,13 @@ bool HLSLParser::ParseTopLevel(HLSLStatement*& statement)
 
             HLSLFunction* function = m_tree->AddNode<HLSLFunction>(fileName, line);
             function->name                  = globalName;
-            function->returnType.baseType   = type;
-            function->returnType.typeName   = typeName;
+            function->returnType.baseType   = type.baseType;
+            function->returnType.typeName   = type.typeName;
+            function->attributes            = attributes;
 
             BeginScope();
 
-            if (!ParseArgumentList(function->argument, function->numArguments))
+            if (!ParseArgumentList(function->argument, function->numArguments, function->numOutputArguments))
             {
                 return false;
             }
@@ -1437,6 +1473,7 @@ bool HLSLParser::ParseTopLevel(HLSLStatement*& statement)
 
             // Note, no semi-colon at the end of a function declaration.
             statement = function;
+            
             return true;
         }
         else
@@ -1444,8 +1481,7 @@ bool HLSLParser::ParseTopLevel(HLSLStatement*& statement)
             // Uniform declaration.
             HLSLDeclaration* declaration = m_tree->AddNode<HLSLDeclaration>(fileName, line);
             declaration->name            = globalName;
-            declaration->type.baseType   = type;
-            declaration->type.flags      = typeFlags;
+            declaration->type            = type;
 
             // Handle array syntax.
             if (Accept('['))
@@ -1502,22 +1538,31 @@ bool HLSLParser::ParseTopLevel(HLSLStatement*& statement)
     return doesNotExpectSemicolon || Expect(';');
 }
 
-bool HLSLParser::ParseStatementOrBlock(HLSLStatement*& firstStatement, const HLSLType& returnType)
+bool HLSLParser::ParseStatementOrBlock(HLSLStatement*& firstStatement, const HLSLType& returnType, bool scoped/*=true*/)
 {
-    if (Accept('{'))
+    if (scoped)
     {
         BeginScope();
+    }
+    if (Accept('{'))
+    {
         if (!ParseBlock(firstStatement, returnType))
         {
             return false;
         }
-        EndScope();
-        return true;
     }
     else
     {
-        return ParseStatement(firstStatement, returnType);
+        if (!ParseStatement(firstStatement, returnType))
+        {
+            return false;
+        }
     }
+    if (scoped)
+    {
+        EndScope();
+    }
+    return true;
 }
 
 bool HLSLParser::ParseBlock(HLSLStatement*& firstStatement, const HLSLType& returnType)
@@ -1545,6 +1590,7 @@ bool HLSLParser::ParseBlock(HLSLStatement*& firstStatement, const HLSLType& retu
                 lastStatement->nextStatement = statement;
             }
             lastStatement = statement;
+            while (lastStatement->nextStatement) lastStatement = lastStatement->nextStatement;
         }
     }
     return true;
@@ -1564,6 +1610,74 @@ bool HLSLParser::ParseStatement(HLSLStatement*& statement, const HLSLType& retur
     HLSLAttribute * attributes = NULL;
     ParseAttributeBlock(attributes);    // @@ Leak if not assigned to node? 
 
+#if 0 // @@ Work in progress.
+    // Static statements: @if only for now.
+    if (Accept('@'))
+    {
+        if (Accept(HLSLToken_If))
+        {
+            //HLSLIfStatement* ifStatement = m_tree->AddNode<HLSLIfStatement>(fileName, line);
+            //ifStatement->isStatic = true;
+            //ifStatement->attributes = attributes;
+            
+            HLSLExpression * condition = NULL;
+            
+            m_allowUndeclaredIdentifiers = true;    // Not really correct... better to push to stack?
+            if (!Expect('(') || !ParseExpression(condition) || !Expect(')'))
+            {
+                m_allowUndeclaredIdentifiers = false;
+                return false;
+            }
+            m_allowUndeclaredIdentifiers = false;
+            
+            if ((condition->expressionType.flags & HLSLTypeFlag_Const) == 0)
+            {
+                m_tokenizer.Error("Syntax error: @if condition is not constant");
+                return false;
+            }
+            
+            int conditionValue;
+            if (!m_tree->GetExpressionValue(condition, conditionValue))
+            {
+                m_tokenizer.Error("Syntax error: Cannot evaluate @if condition");
+                return false;
+            }
+            
+            if (!conditionValue) m_disableSemanticValidation = true;
+            
+            HLSLStatement * ifStatements = NULL;
+            HLSLStatement * elseStatements = NULL;
+            
+            if (!ParseStatementOrBlock(ifStatements, returnType, /*scoped=*/false))
+            {
+                m_disableSemanticValidation = false;
+                return false;
+            }
+            if (Accept(HLSLToken_Else))
+            {
+                if (conditionValue) m_disableSemanticValidation = true;
+                
+                if (!ParseStatementOrBlock(elseStatements, returnType, /*scoped=*/false))
+                {
+                    m_disableSemanticValidation = false;
+                    return false;
+                }
+            }
+            m_disableSemanticValidation = false;
+            
+            if (conditionValue) statement = ifStatements;
+            else statement = elseStatements;
+            
+            // @@ Free the pruned statements?
+            
+            return true;
+        }
+        else {
+            m_tokenizer.Error("Syntax error: unexpected token '@'");
+        }
+    }
+#endif
+    
     // If statement.
     if (Accept(HLSLToken_If))
     {
@@ -1584,7 +1698,7 @@ bool HLSLParser::ParseStatement(HLSLStatement*& statement, const HLSLType& retur
         }
         return true;
     }
-
+    
     // For statement.
     if (Accept(HLSLToken_For))
     {
@@ -1708,7 +1822,7 @@ bool HLSLParser::ParseDeclaration(HLSLDeclaration*& declaration)
     int         line        = GetLineNumber();
 
     HLSLType type;
-    if (!AcceptType(/*allowVoid=*/false, type.baseType, type.typeName, &type.flags))
+    if (!AcceptType(/*allowVoid=*/false, type))
     {
         return false;
     }
@@ -2018,6 +2132,10 @@ bool HLSLParser::ParseBinaryExpression(int priority, HLSLExpression*& expression
 
                 return false;
             }
+            
+            // Propagate constness.
+            binaryExpression->expressionType.flags = (expression->expressionType.flags | expression2->expressionType.flags) & HLSLTypeFlag_Const;
+            
             expression = binaryExpression;
         }
         else if (_conditionalOpPriority > priority && Accept('?'))
@@ -2112,6 +2230,9 @@ bool HLSLParser::ParseTerminalExpression(HLSLExpression*& expression, bool& need
         if (unaryOp == HLSLUnaryOp_Not)
         {
             unaryExpression->expressionType = HLSLType(HLSLBaseType_Bool);
+            
+            // Propagate constness.
+            unaryExpression->expressionType.flags = unaryExpression->expression->expressionType.flags & HLSLTypeFlag_Const;
         }
         else
         {
@@ -2126,7 +2247,7 @@ bool HLSLParser::ParseTerminalExpression(HLSLExpression*& expression, bool& need
     {
         // Check for a casting operator.
         HLSLType type;
-        if (AcceptType(false, type.baseType, type.typeName, &type.flags))
+        if (AcceptType(false, type))
         {
             // This is actually a type constructor like (float2(...
             if (Accept('('))
@@ -2204,24 +2325,24 @@ bool HLSLParser::ParseTerminalExpression(HLSLExpression*& expression, bool& need
         }
 
         // Type constructor.
-        HLSLBaseType    type;
-        const char*     typeName = NULL;
-        if (AcceptType(/*allowVoid=*/false, type, typeName, NULL))
+        HLSLType type;
+        if (AcceptType(/*allowVoid=*/false, type))
         {
             Expect('(');
-            if (!ParsePartialConstructor(expression, type, typeName))
+            if (!ParsePartialConstructor(expression, type.baseType, type.typeName))
             {
                 return false;
             }
         }
         else
         {
-
             HLSLIdentifierExpression* identifierExpression = m_tree->AddNode<HLSLIdentifierExpression>(fileName, line);
             if (!ExpectIdentifier(identifierExpression->name))
             {
                 return false;
             }
+
+            bool undeclaredIdentifier = false;
 
             const HLSLType* identifierType = FindVariable(identifierExpression->name, identifierExpression->global);
             if (identifierType != NULL)
@@ -2230,16 +2351,37 @@ bool HLSLParser::ParseTerminalExpression(HLSLExpression*& expression, bool& need
             }
             else
             {
-                if (!GetIsFunction(identifierExpression->name))
+                if (GetIsFunction(identifierExpression->name))
+                {
+                    // Functions are always global scope.
+                    identifierExpression->global = true;
+                }
+                else
+                {
+                    undeclaredIdentifier = true;
+                }
+            }
+
+            if (undeclaredIdentifier)
+            {
+                if (m_allowUndeclaredIdentifiers)
+                {
+                    HLSLLiteralExpression* literalExpression = m_tree->AddNode<HLSLLiteralExpression>(fileName, line);
+                    literalExpression->bValue = false;
+                    literalExpression->type = HLSLBaseType_Bool;
+                    literalExpression->expressionType.baseType = literalExpression->type;
+                    literalExpression->expressionType.flags = HLSLTypeFlag_Const;
+                    expression = literalExpression;
+                }
+                else
                 {
                     m_tokenizer.Error("Undeclared identifier '%s'", identifierExpression->name);
                     return false;
                 }
-                // Functions are always global scope.
-                identifierExpression->global = true;
             }
-
-            expression = identifierExpression;
+            else {
+                expression = identifierExpression;
+            }
         }
     }
 
@@ -2432,7 +2574,7 @@ bool HLSLParser::ParseExpressionList(int endToken, bool allowEmptyEnd, HLSLExpre
     return true;
 }
 
-bool HLSLParser::ParseArgumentList(HLSLArgument*& firstArgument, int& numArguments)
+bool HLSLParser::ParseArgumentList(HLSLArgument*& firstArgument, int& numArguments, int& numOutputArguments)
 {
     const char* fileName = GetFileName();
     int         line     = GetLineNumber();
@@ -2489,6 +2631,10 @@ bool HLSLParser::ParseArgumentList(HLSLArgument*& firstArgument, int& numArgumen
         lastArgument = argument;
 
         ++numArguments;
+        if (argument->modifier == HLSLArgumentModifier_Out || argument->modifier == HLSLArgumentModifier_Inout)
+        {
+            ++numOutputArguments;
+        }
     }
     return true;
 }
@@ -2950,6 +3096,7 @@ bool HLSLParser::ParseAttributeList(HLSLAttribute*& firstAttribute)
         if (strcmp(identifier, "unroll") == 0) attribute->attributeType = HLSLAttributeType_Unroll;
         else if (strcmp(identifier, "flatten") == 0) attribute->attributeType = HLSLAttributeType_Flatten;
         else if (strcmp(identifier, "branch") == 0) attribute->attributeType = HLSLAttributeType_Branch;
+        else if (strcmp(identifier, "nofastmath") == 0) attribute->attributeType = HLSLAttributeType_NoFastMath;
         
         // @@ parse arguments, () not required if attribute constructor has no arguments.
 
@@ -3066,6 +3213,7 @@ bool HLSLParser::Parse(HLSLTree* tree)
                 lastStatement->nextStatement = statement;
             }
             lastStatement = statement;
+            while (lastStatement->nextStatement) lastStatement = lastStatement->nextStatement;
         }
     }
     return true;
@@ -3140,143 +3288,172 @@ bool HLSLParser::AcceptInterpolationModifier(int& flags)
 }
 
 
-bool HLSLParser::AcceptType(bool allowVoid, HLSLBaseType& type, const char*& typeName, int* typeFlags)
+bool HLSLParser::AcceptType(bool allowVoid, HLSLType& type/*, bool acceptFlags*/)
 {
-    if (typeFlags != NULL) {
-        *typeFlags = 0;
-        while(AcceptTypeModifier(*typeFlags) || AcceptInterpolationModifier(*typeFlags)) {}
+    //if (type.flags != NULL)
+    {
+        type.flags = 0;
+        while(AcceptTypeModifier(type.flags) || AcceptInterpolationModifier(type.flags)) {}
     }
 
     int token = m_tokenizer.GetToken();
 
     // Check built-in types.
-    type = HLSLBaseType_Void;
+    type.baseType = HLSLBaseType_Void;
     switch (token)
     {
     case HLSLToken_Float:
-        type = HLSLBaseType_Float;
+        type.baseType = HLSLBaseType_Float;
         break;
     case HLSLToken_Float2:      
-        type = HLSLBaseType_Float2;
+        type.baseType = HLSLBaseType_Float2;
         break;
     case HLSLToken_Float3:
-        type = HLSLBaseType_Float3;
+        type.baseType = HLSLBaseType_Float3;
         break;
     case HLSLToken_Float4:
-        type = HLSLBaseType_Float4;
+        type.baseType = HLSLBaseType_Float4;
         break;
 	case HLSLToken_Float2x2:
-		type = HLSLBaseType_Float2x2;
+		type.baseType = HLSLBaseType_Float2x2;
 		break;
     case HLSLToken_Float3x3:
-        type = HLSLBaseType_Float3x3;
+        type.baseType = HLSLBaseType_Float3x3;
         break;
     case HLSLToken_Float4x4:
-        type = HLSLBaseType_Float4x4;
+        type.baseType = HLSLBaseType_Float4x4;
         break;
     case HLSLToken_Float4x3:
-        type = HLSLBaseType_Float4x3;
+        type.baseType = HLSLBaseType_Float4x3;
         break;
     case HLSLToken_Float4x2:
-        type = HLSLBaseType_Float4x2;
+        type.baseType = HLSLBaseType_Float4x2;
         break;
     case HLSLToken_Half:
-        type = HLSLBaseType_Half;
+        type.baseType = HLSLBaseType_Half;
         break;
     case HLSLToken_Half2:      
-        type = HLSLBaseType_Half2;
+        type.baseType = HLSLBaseType_Half2;
         break;
     case HLSLToken_Half3:
-        type = HLSLBaseType_Half3;
+        type.baseType = HLSLBaseType_Half3;
         break;
     case HLSLToken_Half4:
-        type = HLSLBaseType_Half4;
+        type.baseType = HLSLBaseType_Half4;
         break;
 	case HLSLToken_Half2x2:
-		type = HLSLBaseType_Half2x2;
+		type.baseType = HLSLBaseType_Half2x2;
 		break;
     case HLSLToken_Half3x3:
-        type = HLSLBaseType_Half3x3;
+        type.baseType = HLSLBaseType_Half3x3;
         break;
     case HLSLToken_Half4x4:
-        type = HLSLBaseType_Half4x4;
+        type.baseType = HLSLBaseType_Half4x4;
         break;
     case HLSLToken_Half4x3:
-        type = HLSLBaseType_Half4x3;
+        type.baseType = HLSLBaseType_Half4x3;
         break;
     case HLSLToken_Half4x2:
-        type = HLSLBaseType_Half4x2;
+        type.baseType = HLSLBaseType_Half4x2;
         break;
     case HLSLToken_Bool:
-        type = HLSLBaseType_Bool;
+        type.baseType = HLSLBaseType_Bool;
         break;
 	case HLSLToken_Bool2:
-		type = HLSLBaseType_Bool2;
+		type.baseType = HLSLBaseType_Bool2;
 		break;
 	case HLSLToken_Bool3:
-		type = HLSLBaseType_Bool3;
+		type.baseType = HLSLBaseType_Bool3;
 		break;
 	case HLSLToken_Bool4:
-		type = HLSLBaseType_Bool4;
+		type.baseType = HLSLBaseType_Bool4;
 		break;
     case HLSLToken_Int:
-        type = HLSLBaseType_Int;
+        type.baseType = HLSLBaseType_Int;
         break;
     case HLSLToken_Int2:
-        type = HLSLBaseType_Int2;
+        type.baseType = HLSLBaseType_Int2;
         break;
     case HLSLToken_Int3:
-        type = HLSLBaseType_Int3;
+        type.baseType = HLSLBaseType_Int3;
         break;
     case HLSLToken_Int4:
-        type = HLSLBaseType_Int4;
+        type.baseType = HLSLBaseType_Int4;
         break;
     case HLSLToken_Uint:
-        type = HLSLBaseType_Uint;
+        type.baseType = HLSLBaseType_Uint;
         break;
     case HLSLToken_Uint2:
-        type = HLSLBaseType_Uint2;
+        type.baseType = HLSLBaseType_Uint2;
         break;
     case HLSLToken_Uint3:
-        type = HLSLBaseType_Uint3;
+        type.baseType = HLSLBaseType_Uint3;
         break;
     case HLSLToken_Uint4:
-        type = HLSLBaseType_Uint4;
+        type.baseType = HLSLBaseType_Uint4;
         break;
     case HLSLToken_Texture:
-        type = HLSLBaseType_Texture;
+        type.baseType = HLSLBaseType_Texture;
         break;
     case HLSLToken_Sampler:
-        type = HLSLBaseType_Sampler2D;  // @@ IC: For now we assume that generic samplers are always sampler2D
+        type.baseType = HLSLBaseType_Sampler2D;  // @@ IC: For now we assume that generic samplers are always sampler2D
         break;
     case HLSLToken_Sampler2D:
-        type = HLSLBaseType_Sampler2D;
+        type.baseType = HLSLBaseType_Sampler2D;
         break;
     case HLSLToken_Sampler3D:
-        type = HLSLBaseType_Sampler3D;
+        type.baseType = HLSLBaseType_Sampler3D;
         break;
     case HLSLToken_SamplerCube:
-        type = HLSLBaseType_SamplerCube;
+        type.baseType = HLSLBaseType_SamplerCube;
         break;
     case HLSLToken_Sampler2DShadow:
-        type = HLSLBaseType_Sampler2DShadow;
+        type.baseType = HLSLBaseType_Sampler2DShadow;
         break;
     case HLSLToken_Sampler2DMS:
-        type = HLSLBaseType_Sampler2DMS;
+        type.baseType = HLSLBaseType_Sampler2DMS;
         break;
     case HLSLToken_Sampler2DArray:
-        type = HLSLBaseType_Sampler2DArray;
+        type.baseType = HLSLBaseType_Sampler2DArray;
         break;
     }
-    if (type != HLSLBaseType_Void)
+    if (type.baseType != HLSLBaseType_Void)
     {
         m_tokenizer.Next();
+        
+        if (IsSamplerType(type.baseType))
+        {
+            // Parse optional sampler type.
+            if (Accept('<'))
+            {
+                int token = m_tokenizer.GetToken();
+                if (token == HLSLToken_Float)
+                {
+                    type.samplerType = HLSLBaseType_Float;
+                }
+                else if (token == HLSLToken_Half)
+                {
+                    type.samplerType = HLSLBaseType_Half;
+                }
+                else
+                {
+                    m_tokenizer.Error("Expected half or float.");
+                    return false;
+                }
+                m_tokenizer.Next();
+                
+                if (!Expect('>'))
+                {
+                    return false;
+                }
+            }
+        }
         return true;
     }
 
     if (allowVoid && Accept(HLSLToken_Void))
     {
-        type = HLSLBaseType_Void;
+        type.baseType = HLSLBaseType_Void;
         return true;
     }
     if (token == HLSLToken_Identifier)
@@ -3285,17 +3462,17 @@ bool HLSLParser::AcceptType(bool allowVoid, HLSLBaseType& type, const char*& typ
         if (FindUserDefinedType(identifier) != NULL)
         {
             m_tokenizer.Next();
-            type        = HLSLBaseType_UserDefined;
-            typeName    = identifier;
+            type.baseType = HLSLBaseType_UserDefined;
+            type.typeName = identifier;
             return true;
         }
     }
     return false;
 }
 
-bool HLSLParser::ExpectType(bool allowVoid, HLSLBaseType& type, const char*& typeName, int* typeFlags)
+bool HLSLParser::ExpectType(bool allowVoid, HLSLType& type)
 {
-    if (!AcceptType(allowVoid, type, typeName, typeFlags))
+    if (!AcceptType(allowVoid, type))
     {
         m_tokenizer.Error("Expected type");
         return false;
@@ -3305,7 +3482,7 @@ bool HLSLParser::ExpectType(bool allowVoid, HLSLBaseType& type, const char*& typ
 
 bool HLSLParser::AcceptDeclaration(bool allowUnsizedArray, HLSLType& type, const char*& name)
 {
-    if (!AcceptType(/*allowVoid=*/false, type.baseType, type.typeName, &type.flags))
+    if (!AcceptType(/*allowVoid=*/false, type))
     {
         return false;
     }

--- a/src/HLSLParser.h
+++ b/src/HLSLParser.h
@@ -49,8 +49,8 @@ private:
     bool AcceptFloat(float& value);
 	bool AcceptHalf( float& value );
     bool AcceptInt(int& value);
-    bool AcceptType(bool allowVoid, HLSLBaseType& type, const char*& typeName, int* typeFlags);
-    bool ExpectType(bool allowVoid, HLSLBaseType& type, const char*& typeName, int* typeFlags);
+    bool AcceptType(bool allowVoid, HLSLType& type);
+    bool ExpectType(bool allowVoid, HLSLType& type);
     bool AcceptBinaryOperator(int priority, HLSLBinaryOp& binaryOp);
     bool AcceptUnaryOperator(bool pre, HLSLUnaryOp& unaryOp);
     bool AcceptAssign(HLSLBinaryOp& binaryOp);
@@ -66,7 +66,7 @@ private:
 
     bool ParseTopLevel(HLSLStatement*& statement);
     bool ParseBlock(HLSLStatement*& firstStatement, const HLSLType& returnType);
-    bool ParseStatementOrBlock(HLSLStatement*& firstStatement, const HLSLType& returnType);
+    bool ParseStatementOrBlock(HLSLStatement*& firstStatement, const HLSLType& returnType, bool scoped = true);
     bool ParseStatement(HLSLStatement*& statement, const HLSLType& returnType);
     bool ParseDeclaration(HLSLDeclaration*& declaration);
     bool ParseFieldDeclaration(HLSLStructField*& field);
@@ -75,7 +75,7 @@ private:
     bool ParseBinaryExpression(int priority, HLSLExpression*& expression);
     bool ParseTerminalExpression(HLSLExpression*& expression, bool& needsEndParen);
     bool ParseExpressionList(int endToken, bool allowEmptyEnd, HLSLExpression*& firstExpression, int& numExpressions);
-    bool ParseArgumentList(HLSLArgument*& firstArgument, int& numArguments);
+    bool ParseArgumentList(HLSLArgument*& firstArgument, int& numArguments, int& numOutputArguments);
     bool ParseDeclarationAssignment(HLSLDeclaration* declaration);
     bool ParsePartialConstructor(HLSLExpression*& expression, HLSLBaseType type, const char* typeName);
 
@@ -135,6 +135,9 @@ private:
     int                     m_numGlobals;
 
     HLSLTree*               m_tree;
+    
+    bool                    m_allowUndeclaredIdentifiers = false;
+    bool                    m_disableSemanticValidation = false;
 };
 
 }

--- a/src/HLSLTokenizer.cpp
+++ b/src/HLSLTokenizer.cpp
@@ -99,6 +99,7 @@ static bool GetIsSymbol(char c)
     case '.':
     case '<': case '>':
     case '|': case '&': case '^': case '~':
+    case '@':
         return true;
     }
     return false;
@@ -228,7 +229,6 @@ void HLSLTokenizer::Next()
     }
 
     // Must be an identifier or a reserved word.
-
     while (m_buffer < m_bufferEnd && m_buffer[0] != 0 && !GetIsSymbol(m_buffer[0]) && !isspace(m_buffer[0]))
     {
         ++m_buffer;
@@ -237,7 +237,7 @@ void HLSLTokenizer::Next()
     size_t length = m_buffer - start;
     memcpy(m_identifier, start, length);
     m_identifier[length] = 0;
-
+    
     const int numReservedWords = sizeof(_reservedWords) / sizeof(const char*);
     for (int i = 0; i < numReservedWords; ++i)
     {
@@ -623,7 +623,7 @@ void HLSLTokenizer::GetTokenName(int token, char buffer[s_maxIdentifier])
             break;
         case HLSLToken_EndOfStream:
             strcpy(buffer, "<eof>");
-			break;
+            break;
         default:
             strcpy(buffer, "unknown");
             break;

--- a/src/HLSLTokenizer.h
+++ b/src/HLSLTokenizer.h
@@ -92,7 +92,7 @@ enum HLSLToken
     HLSLToken_DivideEqual,
     HLSLToken_AndAnd,       // &&
     HLSLToken_BarBar,       // ||
-
+    
     // Other token types.
     HLSLToken_FloatLiteral,
 	HLSLToken_HalfLiteral,

--- a/src/HLSLTree.cpp
+++ b/src/HLSLTree.cpp
@@ -6,6 +6,100 @@
 namespace M4
 {
 
+const HLSLTypeDimension BaseTypeDimension[HLSLBaseType_Count] =
+{
+    HLSLTypeDimension_None,     // HLSLBaseType_Unknown,
+    HLSLTypeDimension_None,     // HLSLBaseType_Void,
+    HLSLTypeDimension_Scalar,   // HLSLBaseType_Float,
+    HLSLTypeDimension_Vector2,  // HLSLBaseType_Float2,
+    HLSLTypeDimension_Vector3,  // HLSLBaseType_Float3,
+    HLSLTypeDimension_Vector4,  // HLSLBaseType_Float4,
+    HLSLTypeDimension_Matrix2x2,// HLSLBaseType_Float2x2,
+    HLSLTypeDimension_Matrix3x3,// HLSLBaseType_Float3x3,
+    HLSLTypeDimension_Matrix4x4,// HLSLBaseType_Float4x4,
+    HLSLTypeDimension_Matrix4x3,// HLSLBaseType_Float4x3,
+    HLSLTypeDimension_Matrix4x2,// HLSLBaseType_Float4x2,
+    HLSLTypeDimension_Scalar,   // HLSLBaseType_Half,
+    HLSLTypeDimension_Vector2,  // HLSLBaseType_Half2,
+    HLSLTypeDimension_Vector3,  // HLSLBaseType_Half3,
+    HLSLTypeDimension_Vector4,  // HLSLBaseType_Half4,
+    HLSLTypeDimension_Matrix2x2,// HLSLBaseType_Half2x2,
+    HLSLTypeDimension_Matrix3x3,// HLSLBaseType_Half3x3,
+    HLSLTypeDimension_Matrix4x4,// HLSLBaseType_Half4x4,
+    HLSLTypeDimension_Matrix4x3,// HLSLBaseType_Half4x3,
+    HLSLTypeDimension_Matrix4x2,// HLSLBaseType_Half4x2,
+    HLSLTypeDimension_Scalar,   // HLSLBaseType_Bool,
+    HLSLTypeDimension_Vector2,  // HLSLBaseType_Bool2,
+    HLSLTypeDimension_Vector3,  // HLSLBaseType_Bool3,
+    HLSLTypeDimension_Vector4,  // HLSLBaseType_Bool4,
+    HLSLTypeDimension_Scalar,   // HLSLBaseType_Int,
+    HLSLTypeDimension_Vector2,  // HLSLBaseType_Int2,
+    HLSLTypeDimension_Vector3,  // HLSLBaseType_Int3,
+    HLSLTypeDimension_Vector4,  // HLSLBaseType_Int4,
+    HLSLTypeDimension_Scalar,   // HLSLBaseType_Uint,
+    HLSLTypeDimension_Vector2,  // HLSLBaseType_Uint2,
+    HLSLTypeDimension_Vector3,  // HLSLBaseType_Uint3,
+    HLSLTypeDimension_Vector4,  // HLSLBaseType_Uint4,
+    HLSLTypeDimension_None,     // HLSLBaseType_Texture,
+    HLSLTypeDimension_None,     // HLSLBaseType_Sampler,           // @@ use type inference to determine sampler type.
+    HLSLTypeDimension_None,     // HLSLBaseType_Sampler2D,
+    HLSLTypeDimension_None,     // HLSLBaseType_Sampler3D,
+    HLSLTypeDimension_None,     // HLSLBaseType_SamplerCube,
+    HLSLTypeDimension_None,     // HLSLBaseType_Sampler2DShadow,
+    HLSLTypeDimension_None,     // HLSLBaseType_Sampler2DMS,
+    HLSLTypeDimension_None,     // HLSLBaseType_Sampler2DArray,
+    HLSLTypeDimension_None,     // HLSLBaseType_UserDefined,       // struct
+    HLSLTypeDimension_None,     // HLSLBaseType_Expression,        // type argument for defined() sizeof() and typeof().
+    HLSLTypeDimension_None,     // HLSLBaseType_Auto,
+};
+
+const HLSLBaseType ScalarBaseType[HLSLBaseType_Count] = {
+    HLSLBaseType_Unknown,       // HLSLBaseType_Unknown,
+    HLSLBaseType_Void,          // HLSLBaseType_Void,
+    HLSLBaseType_Float,         // HLSLBaseType_Float,
+    HLSLBaseType_Float,         // HLSLBaseType_Float2,
+    HLSLBaseType_Float,         // HLSLBaseType_Float3,
+    HLSLBaseType_Float,         // HLSLBaseType_Float4,
+    HLSLBaseType_Float,         // HLSLBaseType_Float2x2,
+    HLSLBaseType_Float,         // HLSLBaseType_Float3x3,
+    HLSLBaseType_Float,         // HLSLBaseType_Float4x4,
+    HLSLBaseType_Float,         // HLSLBaseType_Float4x3,
+    HLSLBaseType_Float,         // HLSLBaseType_Float4x2,
+    HLSLBaseType_Half,          // HLSLBaseType_Half,
+    HLSLBaseType_Half,          // HLSLBaseType_Half2,
+    HLSLBaseType_Half,          // HLSLBaseType_Half3,
+    HLSLBaseType_Half,          // HLSLBaseType_Half4,
+    HLSLBaseType_Half,          // HLSLBaseType_Half2x2,
+    HLSLBaseType_Half,          // HLSLBaseType_Half3x3,
+    HLSLBaseType_Half,          // HLSLBaseType_Half4x4,
+    HLSLBaseType_Half,          // HLSLBaseType_Half4x3,
+    HLSLBaseType_Half,          // HLSLBaseType_Half4x2,
+    HLSLBaseType_Bool,          // HLSLBaseType_Bool,
+    HLSLBaseType_Bool,          // HLSLBaseType_Bool2,
+    HLSLBaseType_Bool,          // HLSLBaseType_Bool3,
+    HLSLBaseType_Bool,          // HLSLBaseType_Bool4,
+    HLSLBaseType_Int,           // HLSLBaseType_Int,
+    HLSLBaseType_Int,           // HLSLBaseType_Int2,
+    HLSLBaseType_Int,           // HLSLBaseType_Int3,
+    HLSLBaseType_Int,           // HLSLBaseType_Int4,
+    HLSLBaseType_Uint,          // HLSLBaseType_Uint,
+    HLSLBaseType_Uint,          // HLSLBaseType_Uint2,
+    HLSLBaseType_Uint,          // HLSLBaseType_Uint3,
+    HLSLBaseType_Uint,          // HLSLBaseType_Uint4,
+    HLSLBaseType_Unknown,       // HLSLBaseType_Texture,
+    HLSLBaseType_Unknown,       // HLSLBaseType_Sampler,           // @@ use type inference to determine sampler type.
+    HLSLBaseType_Unknown,       // HLSLBaseType_Sampler2D,
+    HLSLBaseType_Unknown,       // HLSLBaseType_Sampler3D,
+    HLSLBaseType_Unknown,       // HLSLBaseType_SamplerCube,
+    HLSLBaseType_Unknown,       // HLSLBaseType_Sampler2DShadow,
+    HLSLBaseType_Unknown,       // HLSLBaseType_Sampler2DMS,
+    HLSLBaseType_Unknown,       // HLSLBaseType_Sampler2DArray,
+    HLSLBaseType_Unknown,       // HLSLBaseType_UserDefined,       // struct
+    HLSLBaseType_Unknown,       // HLSLBaseType_Expression,        // type argument for defined() sizeof() and typeof().
+    HLSLBaseType_Unknown,       // HLSLBaseType_Auto,
+};
+
+
 HLSLTree::HLSLTree(Allocator* allocator) :
     m_allocator(allocator), m_stringPool(allocator)
 {
@@ -634,6 +728,9 @@ void HLSLTreeVisitor::VisitTopLevelStatement(HLSLStatement * node)
     else if (node->nodeType == HLSLNodeType_Technique) {
         VisitTechnique((HLSLTechnique *)node);
     }
+    else if (node->nodeType == HLSLNodeType_Pipeline) {
+        VisitPipeline((HLSLPipeline *)node);
+    }
     else {
         ASSERT(0);
     }
@@ -916,6 +1013,11 @@ void HLSLTreeVisitor::VisitTechnique(HLSLTechnique * node)
         VisitPass(pass);
         pass = pass->nextPass;
     }
+}
+
+void HLSLTreeVisitor::VisitPipeline(HLSLPipeline * node)
+{
+    // @@ ?
 }
 
 void HLSLTreeVisitor::VisitFunctions(HLSLRoot * root)
@@ -1392,7 +1494,7 @@ public:
         VisitStatements(function->statement);
         return found;
     }
-
+    
     virtual void VisitStatements(HLSLStatement * statement) override
     {
         while (statement != NULL && !found)
@@ -1474,7 +1576,8 @@ bool EmulateAlphaTest(HLSLTree* tree, const char* entryName, float alphaRef/*=0.
                 {
                     alpha = returnStatement->expression;     // @@ Is reference OK? Or should we clone expression?
                 }
-                else {
+                else
+                {
                     return false;
                 }
                 
@@ -1503,6 +1606,357 @@ bool EmulateAlphaTest(HLSLTree* tree, const char* entryName, float alphaRef/*=0.
     }
 
     return true;
+}
+
+bool NeedsFlattening(HLSLExpression * expr, int level = 0) {
+    if (expr == NULL) {
+        return false;
+    }
+    if (expr->nodeType == HLSLNodeType_UnaryExpression) {
+        HLSLUnaryExpression * unaryExpr = (HLSLUnaryExpression *)expr;
+        return NeedsFlattening(unaryExpr->expression, level+1) || NeedsFlattening(expr->nextExpression, level);
+    }
+    else if (expr->nodeType == HLSLNodeType_BinaryExpression) {
+        HLSLBinaryExpression * binaryExpr = (HLSLBinaryExpression *)expr;
+        if (IsAssignOp(binaryExpr->binaryOp)) {
+            return NeedsFlattening(binaryExpr->expression2, level+1) || NeedsFlattening(expr->nextExpression, level);
+        }
+        else {
+            return NeedsFlattening(binaryExpr->expression1, level+1) || NeedsFlattening(binaryExpr->expression2, level+1) || NeedsFlattening(expr->nextExpression, level);
+        }
+    }
+    else if (expr->nodeType == HLSLNodeType_ConditionalExpression) {
+        HLSLConditionalExpression * conditionalExpr = (HLSLConditionalExpression *)expr;
+        return NeedsFlattening(conditionalExpr->condition, level+1) || NeedsFlattening(conditionalExpr->trueExpression, level+1) || NeedsFlattening(conditionalExpr->falseExpression, level+1) || NeedsFlattening(expr->nextExpression, level);
+    }
+    else if (expr->nodeType == HLSLNodeType_CastingExpression) {
+        HLSLCastingExpression * castingExpr = (HLSLCastingExpression *)expr;
+        return NeedsFlattening(castingExpr->expression, level+1) || NeedsFlattening(expr->nextExpression, level);
+    }
+    else if (expr->nodeType == HLSLNodeType_LiteralExpression) {
+        return NeedsFlattening(expr->nextExpression, level);
+    }
+    else if (expr->nodeType == HLSLNodeType_IdentifierExpression) {
+        return NeedsFlattening(expr->nextExpression, level);
+    }
+    else if (expr->nodeType == HLSLNodeType_ConstructorExpression) {
+        HLSLConstructorExpression * constructorExpr = (HLSLConstructorExpression *)expr;
+        return NeedsFlattening(constructorExpr->argument, level+1) || NeedsFlattening(expr->nextExpression, level);
+    }
+    else if (expr->nodeType == HLSLNodeType_MemberAccess) {
+        return NeedsFlattening(expr->nextExpression, level+1);
+    }
+    else if (expr->nodeType == HLSLNodeType_ArrayAccess) {
+        HLSLArrayAccess * arrayAccess = (HLSLArrayAccess *)expr;
+        return NeedsFlattening(arrayAccess->array, level+1) || NeedsFlattening(arrayAccess->index, level+1) || NeedsFlattening(expr->nextExpression, level);
+    }
+    else if (expr->nodeType == HLSLNodeType_FunctionCall) {
+        HLSLFunctionCall * functionCall = (HLSLFunctionCall *)expr;
+        if (functionCall->function->numOutputArguments > 0) {
+            if (level > 0) {
+                return true;
+            }
+        }
+        return NeedsFlattening(functionCall->argument, level+1) || NeedsFlattening(expr->nextExpression, level);
+    }
+    else {
+        //assert(false);
+        return false;
+    }
+}
+
+
+struct StatementList {
+    HLSLStatement * head = NULL;
+    HLSLStatement * tail = NULL;
+    void append(HLSLStatement * st) {
+        if (head == NULL) {
+            tail = head = st;
+        }
+        tail->nextStatement = st;
+        tail = st;
+    }
+};
+
+
+    class ExpressionFlattener : public HLSLTreeVisitor
+    {
+    public:
+        HLSLTree * m_tree;
+        int tmp_index;
+        HLSLStatement ** statement_pointer;
+        HLSLFunction * current_function;
+        
+        ExpressionFlattener()
+        {
+            m_tree = NULL;
+            tmp_index = 0;
+            statement_pointer = NULL;
+            current_function = NULL;
+        }
+        
+        void FlattenExpressions(HLSLTree * tree)
+        {
+            m_tree = tree;
+            VisitRoot(tree->GetRoot());
+        }
+
+        // Visit all statements updating the statement_pointer so that we can insert and replace statements. @@ Add this to the default visitor?
+        virtual void VisitFunction(HLSLFunction * node) override
+        {
+            current_function = node;
+            statement_pointer = &node->statement;
+            VisitStatements(node->statement);
+            statement_pointer = NULL;
+            current_function = NULL;
+        }
+
+        virtual void VisitIfStatement(HLSLIfStatement * node) override
+        {
+            if (NeedsFlattening(node->condition, 1)) {
+                assert(false);  // @@ Add statements before if statement.
+            }
+            
+            statement_pointer = &node->statement;
+            VisitStatements(node->statement);
+            if (node->elseStatement) {
+                statement_pointer = &node->elseStatement;
+                VisitStatements(node->elseStatement);
+            }
+        }
+        
+        virtual void VisitForStatement(HLSLForStatement * node) override
+        {
+            if (NeedsFlattening(node->initialization->assignment, 1)) {
+                assert(false);  // @@ Add statements before for statement.
+            }
+            if (NeedsFlattening(node->condition, 1) || NeedsFlattening(node->increment, 1)) {
+                assert(false);  // @@ These are tricky to implement. Need to handle all loop exits.
+            }
+
+            statement_pointer = &node->statement;
+            VisitStatements(node->statement);
+        }
+        
+        virtual void VisitBlockStatement(HLSLBlockStatement * node) override
+        {
+            statement_pointer = &node->statement;
+            VisitStatements(node->statement);
+        }
+        
+        virtual void VisitStatements(HLSLStatement * statement) override
+        {
+            while (statement != NULL) {
+                VisitStatement(statement);
+                statement_pointer = &statement->nextStatement;
+                statement = statement->nextStatement;
+            }
+        }
+
+        // This is usually a function call or assignment.
+        virtual void VisitExpressionStatement(HLSLExpressionStatement * node) override
+        {
+            if (NeedsFlattening(node->expression, 0))
+            {
+                StatementList statements;
+                Flatten(node->expression, statements, false);
+                
+                // Link beginning of statement list.
+                *statement_pointer = statements.head;
+
+                // Link end of statement list.
+                HLSLStatement * tail = statements.tail;
+                tail->nextStatement = node->nextStatement;
+                
+                // Update statement pointer.
+                statement_pointer = &tail->nextStatement;
+                
+                // @@ Delete node?
+            }
+        }
+
+        virtual void VisitDeclaration(HLSLDeclaration * node) override
+        {
+            // Skip global declarations.
+            if (statement_pointer == NULL) return;
+            
+            if (NeedsFlattening(node->assignment, 1))
+            {
+                StatementList statements;
+                HLSLIdentifierExpression * ident = Flatten(node->assignment, statements, true);
+                
+                // @@ Delete node->assignment?
+                
+                node->assignment = ident;
+                statements.append(node);
+                
+                // Link beginning of statement list.
+                *statement_pointer = statements.head;
+                
+                // Link end of statement list.
+                HLSLStatement * tail = statements.tail;
+                tail->nextStatement = node->nextStatement;
+                
+                // Update statement pointer.
+                statement_pointer = &tail->nextStatement;
+            }
+        }
+
+        virtual void VisitReturnStatement(HLSLReturnStatement * node) override
+        {
+            if (NeedsFlattening(node->expression, 1))
+            {
+                StatementList statements;
+                HLSLIdentifierExpression * ident = Flatten(node->expression, statements, true);
+
+                // @@ Delete node->expression?
+                
+                node->expression = ident;
+                statements.append(node);
+                
+                // Link beginning of statement list.
+                *statement_pointer = statements.head;
+                
+                // Link end of statement list.
+                HLSLStatement * tail = statements.tail;
+                tail->nextStatement = node->nextStatement;
+                
+                // Update statement pointer.
+                statement_pointer = &tail->nextStatement;
+            }
+        }
+
+        
+        HLSLDeclaration * BuildTemporaryDeclaration(HLSLExpression * expr)
+        {
+            assert(expr->expressionType.baseType != HLSLBaseType_Void);
+            
+            HLSLDeclaration * declaration = m_tree->AddNode<HLSLDeclaration>(expr->fileName, expr->line);
+            declaration->name = m_tree->AddStringFormat("tmp%d", tmp_index++);
+            declaration->type = expr->expressionType;
+            declaration->assignment = expr;
+            
+            HLSLIdentifierExpression * ident = (HLSLIdentifierExpression *)expr;
+            
+            return declaration;
+        }
+
+        HLSLExpressionStatement * BuildExpressionStatement(HLSLExpression * expr)
+        {
+            HLSLExpressionStatement * statement = m_tree->AddNode<HLSLExpressionStatement>(expr->fileName, expr->line);
+            statement->expression = expr;
+            return statement;
+        }
+
+        HLSLIdentifierExpression * AddExpressionStatement(HLSLExpression * expr, StatementList & statements, bool wantIdent)
+        {
+            if (wantIdent) {
+                HLSLDeclaration * declaration = BuildTemporaryDeclaration(expr);
+                statements.append(declaration);
+                
+                HLSLIdentifierExpression * ident = m_tree->AddNode<HLSLIdentifierExpression>(expr->fileName, expr->line);
+                ident->name = declaration->name;
+                ident->expressionType = declaration->type;
+                return ident;
+            }
+            else {
+                HLSLExpressionStatement * statement = BuildExpressionStatement(expr);
+                statements.append(statement);
+                return NULL;
+            }
+        }
+        
+        HLSLIdentifierExpression * Flatten(HLSLExpression * expr, StatementList & statements, bool wantIdent = true)
+        {
+            if (!NeedsFlattening(expr, wantIdent)) {
+                return AddExpressionStatement(expr, statements, wantIdent);
+            }
+            
+            if (expr->nodeType == HLSLNodeType_UnaryExpression) {
+                assert(expr->nextExpression == NULL);
+                
+                HLSLUnaryExpression * unaryExpr = (HLSLUnaryExpression *)expr;
+                
+                HLSLIdentifierExpression * tmp = Flatten(unaryExpr->expression, statements, true);
+                
+                HLSLUnaryExpression * newUnaryExpr = m_tree->AddNode<HLSLUnaryExpression>(unaryExpr->fileName, unaryExpr->line);
+                newUnaryExpr->unaryOp = unaryExpr->unaryOp;
+                newUnaryExpr->expression = tmp;
+                newUnaryExpr->expressionType = unaryExpr->expressionType;
+
+                return AddExpressionStatement(newUnaryExpr, statements, wantIdent);
+            }
+            else if (expr->nodeType == HLSLNodeType_BinaryExpression) {
+                assert(expr->nextExpression == NULL);
+                
+                HLSLBinaryExpression * binaryExpr = (HLSLBinaryExpression *)expr;
+                
+                if (IsAssignOp(binaryExpr->binaryOp)) {
+                    // Flatten right hand side only.
+                    HLSLIdentifierExpression * tmp2 = Flatten(binaryExpr->expression2, statements, true);
+                    
+                    HLSLBinaryExpression * newBinaryExpr = m_tree->AddNode<HLSLBinaryExpression>(binaryExpr->fileName, binaryExpr->line);
+                    newBinaryExpr->binaryOp = binaryExpr->binaryOp;
+                    newBinaryExpr->expression1 = binaryExpr->expression1;
+                    newBinaryExpr->expression2 = tmp2;
+                    newBinaryExpr->expressionType = binaryExpr->expressionType;
+                    
+                    return AddExpressionStatement(newBinaryExpr, statements, wantIdent);
+                }
+                else {
+                    HLSLIdentifierExpression * tmp1 = Flatten(binaryExpr->expression1, statements, true);
+                    HLSLIdentifierExpression * tmp2 = Flatten(binaryExpr->expression2, statements, true);
+
+                    HLSLBinaryExpression * newBinaryExpr = m_tree->AddNode<HLSLBinaryExpression>(binaryExpr->fileName, binaryExpr->line);
+                    newBinaryExpr->binaryOp = binaryExpr->binaryOp;
+                    newBinaryExpr->expression1 = tmp1;
+                    newBinaryExpr->expression2 = tmp2;
+                    newBinaryExpr->expressionType = binaryExpr->expressionType;
+                    
+                    return AddExpressionStatement(newBinaryExpr, statements, wantIdent);
+                }
+            }
+            else if (expr->nodeType == HLSLNodeType_ConditionalExpression) {
+                assert(false);
+            }
+            else if (expr->nodeType == HLSLNodeType_CastingExpression) {
+                assert(false);
+            }
+            else if (expr->nodeType == HLSLNodeType_LiteralExpression) {
+                assert(false);
+            }
+            else if (expr->nodeType == HLSLNodeType_IdentifierExpression) {
+                assert(false);
+            }
+            else if (expr->nodeType == HLSLNodeType_ConstructorExpression) {
+                assert(false);
+            }
+            else if (expr->nodeType == HLSLNodeType_MemberAccess) {
+                assert(false);
+            }
+            else if (expr->nodeType == HLSLNodeType_ArrayAccess) {
+                assert(false);
+            }
+            else if (expr->nodeType == HLSLNodeType_FunctionCall) {
+                HLSLFunctionCall * functionCall = (HLSLFunctionCall *)expr;
+
+                // @@ Output function as is?
+                // @@ We have to flatten function arguments! This is tricky, need to handle input/output arguments.
+                assert(!NeedsFlattening(functionCall->argument));
+                
+                return AddExpressionStatement(expr, statements, wantIdent);
+            }
+            else {
+                assert(false);
+            }
+            return NULL;
+        }
+    };
+
+    
+void FlattenExpressions(HLSLTree* tree) {
+    ExpressionFlattener flattener;
+    flattener.FlattenExpressions(tree);
 }
 
 } // M4

--- a/src/MSLGenerator.h
+++ b/src/MSLGenerator.h
@@ -35,12 +35,18 @@ public:
         unsigned int flags;
         unsigned int bufferRegisterOffset;
         int (*attributeCallback)(const char* name, unsigned int index);
+        bool treatHalfAsFloat;
+        bool usePreciseFma;
+        bool use16BitIntegers;
 
         Options()
         {
             flags = 0;
             bufferRegisterOffset = 0;
             attributeCallback = NULL;
+            treatHalfAsFloat = true;
+            usePreciseFma = false;
+            use16BitIntegers = false;
         }
     };
 
@@ -82,19 +88,26 @@ private:
     void OutputBuffer(int indent, HLSLBuffer* buffer);
     void OutputFunction(int indent, HLSLFunction* function);
     void OutputExpression(HLSLExpression* expression, HLSLExpression* parentExpression);
+    void OutputTypedExpression(const HLSLType& type, HLSLExpression* expression, HLSLExpression* parentExpression);
+    bool NeedsCast(const HLSLType & target, const HLSLType & source);
     void OutputCast(const HLSLType& type);
     
     void OutputArguments(HLSLArgument* argument);
     void OutputDeclaration(const HLSLType& type, const char* name, HLSLExpression* assignment, bool isRef = false, bool isConst = false, int alignment = 0);
-    void OutputDeclarationType(const HLSLType& type, bool isConst = false, bool isRef = false, int alignment = 0);
+    void OutputDeclarationType(const HLSLType& type, bool isConst = false, bool isRef = false, int alignment = 0, bool isTypeCast = false);
     void OutputDeclarationBody(const HLSLType& type, const char* name, HLSLExpression* assignment, bool isRef = false);
     void OutputExpressionList(HLSLExpression* expression);
-    void OutputFunctionCallStatement(int indent, HLSLFunctionCall* functionCall);
-    void OutputFunctionCall(HLSLFunctionCall* functionCall);
+    void OutputExpressionList(const HLSLType& type, HLSLExpression* expression);
+    void OutputExpressionList(HLSLArgument* argument, HLSLExpression* expression);
+    
+    void OutputFunctionCallStatement(int indent, HLSLFunctionCall* functionCall, HLSLDeclaration* assingmentExpression);
+    void OutputFunctionCall(HLSLFunctionCall* functionCall, HLSLExpression * parentExpression);
 
     const char* TranslateInputSemantic(const char* semantic);
     const char* TranslateOutputSemantic(const char* semantic);
 
+    const char* GetTypeName(const HLSLType& type, bool exactType);
+    
     void Error(const char* format, ...);
 
 private:
@@ -110,6 +123,8 @@ private:
 
     ClassArgument * m_firstClassArgument;
     ClassArgument * m_lastClassArgument;
+    
+    HLSLFunction *  m_currentFunction;
 };
 
 } // M4


### PR DESCRIPTION
- Added better support for out and inout arguments in the MSL generator. Instead of passing these by reference, output arguments are wrapped in a temporary structure that's passed as return value. To make this work, the corresponding function call arguments need to be flattened and transformed into a list of statements.
- Added support for sample_id semantic.
- Added support for half, with an option to treat half as float in MSL. Support for half required better handling of type casts, since in many cases casts were not implicit as in HLSL.
- Added support for treating integers as 16 bit integers (int -> short, uint->usrhot).
- The generated MSL output is a bit cleaner and some unnecessary parenthesis have been removed.
- Fixed support for some const declarations.
- There's some work in progress to add support for static if and some new hlsl features that didn't make it for the iOS release.