### PR TITLE
MSL: Fix 'static const' variables

### DIFF
--- a/src/MSLGenerator.h
+++ b/src/MSLGenerator.h
@@ -83,6 +83,7 @@ private:
     
     void PrependDeclarations();
     
+    void OutputStaticDeclarations(int indent, HLSLStatement* statement);
     void OutputStatements(int indent, HLSLStatement* statement);
     void OutputAttributes(int indent, HLSLAttribute* attribute);
     void OutputDeclaration(HLSLDeclaration* declaration);


### PR DESCRIPTION
Static const variables are not supported in function scope (because of Metal
restrictions), and also aren't supported in class scope (C++ linking rules).

For them to work, we need to lift them all the way up to global scope because
of this.

This lifting is somewhat naive - it doesn't resolve naming conflicts and does
not lift struct declarations - but it's better than nothing...